### PR TITLE
Fix map popup formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,7 @@
           onEachFeature: function (feature, layer) {
             let popup = "";
             for (const key in feature.properties) {
-              popup += `<strong>$\{key\}</strong>: $\{feature.properties[key]}
-`;
+              popup += `<strong>${key}</strong>: ${feature.properties[key]}<br>`;
             }
             layer.bindPopup(popup || "Unnamed Space");
           }


### PR DESCRIPTION
## Summary
- fix HTML popup template so spaces display across lines

## Testing
- `node -e "console.log('check JSON', JSON.parse(require('fs').readFileSync('spaces.geojson','utf8')).features.length)"`

------
https://chatgpt.com/codex/tasks/task_e_68680ab5aa54832aa11e533da174a59e