### PR TITLE
Reinstate shape editing and persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # QGISmap3
 
-This project displays a Leaflet map with shapes from `spaces.geojson`. The geometry is fixed and served by a small Node.js server.
+This simple Leaflet map allows dragging and scaling GeoJSON shapes. To persist your changes to `spaces.geojson`, run the included Node.js server and use the interface normally.
 
 ## Usage
 
@@ -12,4 +12,5 @@ This project displays a Leaflet map with shapes from `spaces.geojson`. The geome
    ```bash
    node server.js
    ```
-3. Open `http://localhost:3000` in your browser to view the map.
+3. Open `http://localhost:3000` in your browser.
+4. Drag shapes or adjust the scale slider and click **Save** to persist changes. The map also stores the latest state in `localStorage` for convenience.

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html>
 <head>
@@ -12,6 +13,8 @@
 </head>
 <body>
   <div id="map"></div>
+  <input id="scale-control" type="range" min="0.5" max="2" step="0.1" value="1" style="position:absolute;top:10px;left:10px;z-index:1000;">
+  <button id="save-file" style="position:absolute;top:10px;left:160px;z-index:1000;">Save</button>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script>
     const map = L.map('map', {
@@ -23,10 +26,12 @@
     const image = L.imageOverlay('map.png', bounds).addTo(map);
     map.fitBounds(bounds);
 
-    fetch('spaces.geojson')
-      .then(res => res.json())
-      .then(data => {
-        L.geoJSON(data, {
+    let shapesLayer;
+    const saved = localStorage.getItem('shapesGeoJSON');
+    const geojsonPromise = saved ? Promise.resolve(JSON.parse(saved)) : fetch('spaces.geojson').then(res => res.json());
+
+    geojsonPromise.then(data => {
+        shapesLayer = L.geoJSON(data, {
           style: {
             color: "blue",
             fillColor: "yellow",
@@ -39,9 +44,83 @@
               popup += `<strong>${key}</strong>: ${feature.properties[key]}<br>`;
             }
             layer.bindPopup(popup || "Unnamed Space");
+            layer.on('mousedown', startDrag);
           }
         }).addTo(map);
       });
+
+    let dragging = false;
+    let prevLatLng;
+    let currentScale = 1;
+
+    function startDrag(e) {
+      dragging = true;
+      prevLatLng = e.latlng;
+      map.dragging.disable();
+      map.on('mousemove', onDrag);
+      map.on('mouseup', endDrag);
+    }
+
+    function onDrag(e) {
+      if (!dragging) return;
+      const latDiff = e.latlng.lat - prevLatLng.lat;
+      const lngDiff = e.latlng.lng - prevLatLng.lng;
+      shapesLayer.eachLayer(layer => {
+        layer.setLatLngs(shiftLatLngs(layer.getLatLngs(), latDiff, lngDiff));
+      });
+      prevLatLng = e.latlng;
+    }
+
+    function endDrag() {
+      dragging = false;
+      map.dragging.enable();
+      map.off('mousemove', onDrag);
+      map.off('mouseup', endDrag);
+      saveShapes();
+    }
+
+    function shiftLatLngs(latlngs, latDiff, lngDiff) {
+      if (Array.isArray(latlngs[0])) {
+        return latlngs.map(ll => shiftLatLngs(ll, latDiff, lngDiff));
+      }
+      return latlngs.map(ll => L.latLng(ll.lat + latDiff, ll.lng + lngDiff));
+    }
+
+    function scaleLatLngs(latlngs, factor, origin) {
+      if (Array.isArray(latlngs[0])) {
+        return latlngs.map(ll => scaleLatLngs(ll, factor, origin));
+      }
+      return latlngs.map(ll => {
+        const lat = origin.lat + (ll.lat - origin.lat) * factor;
+        const lng = origin.lng + (ll.lng - origin.lng) * factor;
+        return L.latLng(lat, lng);
+      });
+    }
+
+    document.getElementById('scale-control').addEventListener('input', e => {
+      if (!shapesLayer) return;
+      const newScale = parseFloat(e.target.value);
+      const factor = newScale / currentScale;
+      const origin = shapesLayer.getBounds().getCenter();
+      shapesLayer.eachLayer(layer => {
+        layer.setLatLngs(scaleLatLngs(layer.getLatLngs(), factor, origin));
+      });
+      currentScale = newScale;
+      saveShapes();
+    });
+
+    document.getElementById('save-file').addEventListener('click', saveShapes);
+
+    function saveShapes() {
+      if (!shapesLayer) return;
+      const geojson = shapesLayer.toGeoJSON();
+      localStorage.setItem('shapesGeoJSON', JSON.stringify(geojson));
+      fetch('/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(geojson)
+      }).catch(err => console.error('Error saving file', err));
+    }
   </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -1,9 +1,23 @@
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
 
+app.use(express.json({limit: '5mb'}));
 app.use(express.static(__dirname));
+
+app.post('/save', (req, res) => {
+  fs.writeFile(path.join(__dirname, 'spaces.geojson'), JSON.stringify(req.body, null, 2), (err) => {
+    if (err) {
+      console.error('Error saving file:', err);
+      res.status(500).send('Failed to save');
+    } else {
+      res.sendStatus(200);
+    }
+  });
+});
 
 app.listen(PORT, () => {
   console.log(`Server running at http://localhost:${PORT}`);


### PR DESCRIPTION
## Summary
- revert previous merge that removed shape editing features
- restore documentation on dragging and scaling shapes
- re-enable save button, scale slider, and drag handlers
- serve POST `/save` endpoint to persist GeoJSON

## Testing
- `npm install express`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_686ed0e51a00832ab3d4f1e0cc69a544