### PR TITLE
Improve map bounds to show all shapes

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       minZoom: -2
     });
 
-    const bounds = [[0, 0], [842, 1618]];
+    const bounds = L.latLngBounds([[0, 0], [842, 1618]]);
     const image = L.imageOverlay('map.png', bounds).addTo(map);
     map.fitBounds(bounds);
 
@@ -91,6 +91,9 @@
             }
           }).addTo(shapesLayer);
         }
+        const combined = L.latLngBounds(bounds);
+        combined.extend(shapesLayer.getBounds());
+        map.fitBounds(combined);
       });
 
     let dragging = false;


### PR DESCRIPTION
## Summary
- use `L.latLngBounds` when setting static image bounds
- after loading shapes, extend bounds and refit map so off-screen features like the new red shapes become visible

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686edd1d9568832ab5606e01b1135cda